### PR TITLE
Simplifies workspace credentials retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "author": "Adobe Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/aio-cli-lib-console": "^4.0.0",
-    "@adobe/aio-lib-core-config": "^2.0.1",
+    "@adobe/aio-cli-lib-console": "^4.2.0",
+    "@adobe/aio-lib-core-config": "^4.0.0",
     "@adobe/aio-lib-events": "^1.1.5",
     "@adobe/aio-lib-ims": "^4.3.0",
     "@adobe/generator-app-common-lib": "^0.3.3",
@@ -33,9 +33,6 @@
     "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^7.8.7",
     "@types/jest": "^28.1.8",
-    "jest": "^27",
-    "stdout-stderr": "^0.1.13",
-    "yeoman-test": "^6.3.0",
     "eol": "^0.9.1",
     "eslint": "^7.1.0",
     "eslint-config-standard": "^14.1.0",
@@ -44,10 +41,13 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
+    "jest": "^27",
     "js-yaml": "^4.1.0",
+    "lodash.clonedeep": "^4.5.0",
+    "stdout-stderr": "^0.1.13",
     "yeoman-assert": "^3.1.1",
     "yeoman-environment": "^3.2.0",
-    "lodash.clonedeep": "^4.5.0"
+    "yeoman-test": "^6.3.0"
   },
   "peerDependencies": {
     "@adobe/aio-cli-plugin-app-templates": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@adobe/aio-lib-core-config": "^4.0.0",
     "@adobe/aio-lib-events": "^3.1.1",
     "@adobe/aio-lib-ims": "^6.5.0",
-    "@adobe/generator-app-common-lib": "^0.3.3",
+    "@adobe/generator-app-common-lib": "^0.4.1",
     "@oclif/core": "^1.13.10",
     "@oclif/plugin-plugins": "^2.1.0",
     "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/commerce-events-ext-tpl",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "main": "src/index.js",
   "description": "Extensibility template for handling Commerce events",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Adobe Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@adobe/aio-cli-lib-console": "^4.0.0",
+    "@adobe/aio-cli-lib-console": "^4.2.0",
     "@adobe/aio-lib-core-config": "^2.0.1",
     "@adobe/aio-lib-events": "^1.1.5",
     "@adobe/aio-lib-ims": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@adobe/aio-cli-lib-console": "^4.2.0",
-    "@adobe/aio-lib-core-config": "^2.0.1",
+    "@adobe/aio-lib-core-config": "^4.0.0",
     "@adobe/aio-lib-events": "^1.1.5",
     "@adobe/aio-lib-ims": "^4.3.0",
     "@adobe/generator-app-common-lib": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@adobe/aio-cli-lib-console": "^4.2.0",
     "@adobe/aio-lib-core-config": "^4.0.0",
-    "@adobe/aio-lib-events": "^1.1.5",
+    "@adobe/aio-lib-events": "^3.1.1",
     "@adobe/aio-lib-ims": "^4.3.0",
     "@adobe/generator-app-common-lib": "^0.3.3",
     "@oclif/core": "^1.13.10",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@adobe/aio-cli-lib-console": "^4.2.0",
     "@adobe/aio-lib-core-config": "^4.0.0",
     "@adobe/aio-lib-events": "^3.1.1",
-    "@adobe/aio-lib-ims": "^4.3.0",
+    "@adobe/aio-lib-ims": "^6.5.0",
     "@adobe/generator-app-common-lib": "^0.3.3",
     "@oclif/core": "^1.13.10",
     "@oclif/plugin-plugins": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
     "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^7.8.7",
     "@types/jest": "^28.1.8",
-    "jest": "^27",
-    "stdout-stderr": "^0.1.13",
-    "yeoman-test": "^6.3.0",
     "eol": "^0.9.1",
     "eslint": "^7.1.0",
     "eslint-config-standard": "^14.1.0",
@@ -44,10 +41,13 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
+    "jest": "^27",
     "js-yaml": "^4.1.0",
+    "lodash.clonedeep": "^4.5.0",
+    "stdout-stderr": "^0.1.13",
     "yeoman-assert": "^3.1.1",
     "yeoman-environment": "^3.2.0",
-    "lodash.clonedeep": "^4.5.0"
+    "yeoman-test": "^6.3.0"
   },
   "peerDependencies": {
     "@adobe/aio-cli-plugin-app-templates": "^1.0.0"

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,15 +77,9 @@ async function getEventsClient () {
   const cliObject = await context.getCli()
   const apiKey = CONSOLE_API_KEYS[env]
   const consoleCLI = await LibConsoleCLI.init({ accessToken: cliObject.access_token.token, env, apiKey: apiKey })
-  const workspaceCredsOAuth = await consoleCLI.getFirstOAuthServerToServerCredentials(orgId, projectConfig.id, workspace)
-  if(workspaceCredsOAuth === undefined){
-    const workspaceCredsJWT = await consoleCLI.getFirstEntpCredentials(orgId, projectConfig.id, workspace)
-    const clientJWT = await eventsSdk.init(orgCode, workspaceCredsJWT.client_id, accessToken)
-    return clientJWT
-  }else{
-    const clientOAuth = await eventsSdk.init(orgCode, workspaceCredsOAuth.client_id, accessToken)
-    return clientOAuth
-  }
+  const workspaceCreds = await consoleCLI.getFirstWorkspaceCredential(orgId, projectConfig.id, workspace)
+  const client = await eventsSdk.init(orgCode, workspaceCreds.client_id, accessToken)
+  return client
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,13 +77,9 @@ async function getEventsClient () {
   const cliObject = await context.getCli()
   const apiKey = CONSOLE_API_KEYS[env]
   const consoleCLI = await LibConsoleCLI.init({ accessToken: cliObject.access_token.token, env, apiKey: apiKey })
-  const workspaceCredsOAuth = await consoleCLI.getFirstOAuthServerToServerCredentials(orgId, projectConfig.id, workspace)
-  if (workspaceCredsOAuth === undefined) {
-    const workspaceCredsJWT = await consoleCLI.getFirstEntpCredentials(orgId, projectConfig.id, workspace)
-    return await eventsSdk.init(orgCode, workspaceCredsJWT.client_id, accessToken)
-  } else {
-    return await eventsSdk.init(orgCode, workspaceCredsOAuth.client_id, accessToken)
-  }
+  const workspaceCreds = await consoleCLI.getFirstWorkspaceCredential(orgId, projectConfig.id, workspace)
+  const client = await eventsSdk.init(orgCode, workspaceCreds.client_id, accessToken)
+  return client
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,6 +78,9 @@ async function getEventsClient () {
   const apiKey = CONSOLE_API_KEYS[env]
   const consoleCLI = await LibConsoleCLI.init({ accessToken: cliObject.access_token.token, env, apiKey: apiKey })
   const workspaceCreds = await consoleCLI.getFirstWorkspaceCredential(orgId, projectConfig.id, workspace)
+  if (typeof workspaceCreds === 'undefined') {
+    throw new Error('No valid credentials found for Workspace.')
+  }
   const client = await eventsSdk.init(orgCode, workspaceCreds.client_id, accessToken)
   return client
 }


### PR DESCRIPTION
With this new change, the conditional logic to retrieve the workspace credentials of a project will no longer be hardcoded in the template itself. Also all of the Adobe packages in the `package.json` were updated to the latest version to date. 

## Description

The new 4.2.0 release of the _aio-cli-lib-console_ library, includes a new function that takes care of the conditional logic to retrieve a workspace credential depending on the type of auth providers. Based on that, it's no longer needed to have the same logic added to the template. The rest of the Adobe packages were also updated to the latest version to date.

## Related Issue

## Motivation and Context

To keep the template DRY. 

## How Has This Been Tested?

-Initializing and deploying an app for a JWT project
-Initializing and deploying an app for an OAuth project
-Initializing an deploying an app that has migrated from JWT to OAuth.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
